### PR TITLE
App crashes trying to view particular diffs (bugfix attached)

### DIFF
--- a/app/src/main/java/com/bd/gitlab/views/DiffView.java
+++ b/app/src/main/java/com/bd/gitlab/views/DiffView.java
@@ -130,6 +130,9 @@ public class DiffView extends LinearLayout {
 		content.setPadding(PADDING_CONTENT_H, PADDING_CONTENT_V, PADDING_CONTENT_H, PADDING_CONTENT_V);
 		row.addView(content);
 		
+		if(line.lineType == null) //lineContent probably equals "\ No newline at end of file"
+			return row;
+		
 		switch(line.lineType) {
 			case NORMAL:
 				oldLine.setBackgroundColor(LINE_BG);


### PR DESCRIPTION
To reproduce the issue you have to view a commit that appends code to the end of a file (in my case it was a .js file).

The app crashes trying to render "\ No newline at end of file"
The line object would look like this:
line.oldLine= ""
line.newLine = ""
line.lineContent= "\ No newline at end of file"
line.lineType = null

My fix might not be the best way to fix it but at least the app doesn't crash. Returning null instead of row would also result in a crash.
