### PR TITLE
Fixes #21 | Shows title if message is null

### DIFF
--- a/app/src/main/java/com/bd/gitlab/model/DiffLine.java
+++ b/app/src/main/java/com/bd/gitlab/model/DiffLine.java
@@ -66,7 +66,12 @@ public class DiffLine {
 	public List<Line> getLines() {
 		ArrayList<Line> lines = new ArrayList<Line>();
 
-		String[] temp = message.split("\\r?\\n");
+		String[] temp;
+		if (message == null) {
+			temp = new String[]{title};
+		} else {
+			temp = message.split("\\r?\\n");
+		}
 
 		for(String s : temp) {
 			Line line = new Line();


### PR DESCRIPTION
Shows the title of a commit instead of the messsage if message is
null, which happens if a version older than 7.2 of GitLab is used.
Fixes #21.

* patching: @JosephTurner 
* testing: @wfleurant 