### PR TITLE
add WRITE_EXTERNAL_STORAGE permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
This PR will fix the permission needed for storing the file in the external storage.
I have only tested it with gradle 1.2.3, but I don't think it matters. :)